### PR TITLE
Suppress GUI message when file not found

### DIFF
--- a/src/zcl_eui_file.clas.abap
+++ b/src/zcl_eui_file.clas.abap
@@ -240,7 +240,16 @@ METHOD download.
         CONCATENATE lv_path iv_default_filename INTO iv_full_path. " lv_file_name
 
         " Already exist. Create unique name
-        IF cl_gui_frontend_services=>file_exist( iv_full_path ) = abap_true.
+        DATA lv_exist TYPE abap_bool.
+        cl_gui_frontend_services=>file_exist(
+          EXPORTING
+            file = iv_full_path
+          RECEIVING
+            result  = lv_exist
+          EXCEPTIONS
+            OTHERS = 0 "prevent GUI messages when file not found
+        ).
+        IF lv_exist  = abap_true.
           TRY.
               lv_guid = cl_system_uuid=>create_uuid_x16_static( ).
             CATCH cx_uuid_error.

--- a/src/zcl_eui_file.clas.locals_imp.abap
+++ b/src/zcl_eui_file.clas.locals_imp.abap
@@ -66,8 +66,17 @@ CLASS lcl_doi IMPLEMENTATION.
     lo_control->get_document_proxy( EXPORTING document_type  = io_file->ms_ole_info-proxy_app
                                     IMPORTING document_proxy = lo_document ).
 
-    " Show documnet
-    IF cl_gui_frontend_services=>file_exist( io_file->mv_full_path ) = abap_true.
+    " Show document
+    DATA lv_exist TYPE abap_bool.
+    cl_gui_frontend_services=>file_exist(
+      EXPORTING
+        file = io_file->mv_full_path
+      RECEIVING
+        result = lv_exist
+      EXCEPTIONS
+        OTHERS = 0 "prevent GUI messages when file not found
+    ).
+    IF lv_exist = abap_true.
       DATA lv_url TYPE swk_url.
       CONCATENATE `FILE://` io_file->mv_full_path INTO lv_url.
       lo_document->open_document( document_url = lv_url

--- a/src/zfg_eui_screen.fugr.xml
+++ b/src/zfg_eui_screen.fugr.xml
@@ -24,7 +24,6 @@
        <PARAMETER>IO_SCR_MANAGER</PARAMETER>
        <KIND>P</KIND>
        <STEXT>Screen events manager</STEXT>
-       <INDEX> 001</INDEX>
       </RSFDO>
      </DOCUMENTATION>
     </item>


### PR DESCRIPTION
Из-за особенностей cl_gui_frontend_services=>file_exist(), если явно не указать EXCEPTIONS в вызове , будет выводиться сообщение "Incorrect parameter: FILE_NAME". Файла обычно нет, поэтому сообщение выводится каждый раз при показе.