### PR TITLE
Downport to 7.01

### DIFF
--- a/src/zcl_eui_alv.clas.locals_def.abap
+++ b/src/zcl_eui_alv.clas.locals_def.abap
@@ -23,11 +23,13 @@ CLASS lcl_helper DEFINITION FINAL.
 
       prepare_layout
         CHANGING
-          cs_layout LIKE mo_eui_alv->ms_layout,
+          cs_layout TYPE lvc_s_layo,
+*          cs_layout LIKE mo_eui_alv->ms_layout, " lcl_helper is not a friend of zcl_eui_alv
 
       prepare_variant
         CHANGING
-          cs_variant LIKE mo_eui_alv->ms_variant,
+          cs_variant TYPE disvariant,
+*          cs_variant LIKE mo_eui_alv->ms_variant, " lcl_helper is not a friend of zcl_eui_alv
 
       get_field_catalog
         RETURNING VALUE(rt_fieldcat) TYPE lvc_t_fcat,

--- a/src/zcl_eui_conv.clas.abap
+++ b/src/zcl_eui_conv.clas.abap
@@ -4,6 +4,7 @@ class ZCL_EUI_CONV definition
   create public .
 
 public section.
+  type-pools JS .
 
   constants:
     BEGIN OF mc_encoding,
@@ -12,6 +13,7 @@ public section.
       utf_16be TYPE abap_encoding VALUE '4102',
       utf_16le TYPE abap_encoding VALUE '4103',
     END OF mc_encoding .
+
   class-methods MOVE_CORRESPONDING
     importing
       !IS_SOURCE type ANY
@@ -27,14 +29,12 @@ public section.
       !IV_ENCODING type ABAP_ENCODING default MC_ENCODING-UTF_8
     returning
       value(RV_STRING) type STRING .
-
   class-methods BINARY_TO_XSTRING
     importing
       !IT_TABLE type STANDARD TABLE
       !IV_LENGTH type I
     returning
       value(RV_XSTRING) type XSTRING .
-
   class-methods XSTRING_TO_BINARY
     importing
       !IV_XSTRING type XSTRING
@@ -96,6 +96,9 @@ public section.
       !IO_SALV type ref to CL_SALV_MODEL_LIST
     returning
       value(RO_GUI_ALV) type ref to CL_GUI_ALV_GRID .
+  class-methods GUID_CREATE
+    returning
+      value(RV_GUID) type GUID_32 .
 protected section.
 private section.
   class-methods ABAP_2_JSON
@@ -457,6 +460,29 @@ METHOD GET_GRID_FROM_SALV.
       MESSAGE lo_error TYPE 'S' DISPLAY LIKE 'E'.
   ENDTRY.
 ENDMETHOD.
+
+
+method GUID_CREATE.
+  "nearly same approach as in ABAP2XLSX, ZCL_EXCEL_OBSOLETE_FUNC_WRAP:
+  TRY.
+      rv_guid = cl_system_uuid=>create_uuid_c32_static( ).
+    CATCH cx_uuid_error.
+      CONCATENATE sy-datum(4) `-` sy-datum+4(2) `-` sy-datum+6(2) ` `
+                  sy-uzeit(2) `-` sy-uzeit+2(2) `-` sy-uzeit+4(2) INTO rv_guid.
+  ENDTRY.
+
+*--------------------------------------------------------------------*
+*If you are on a release that does not yet have the class cl_system_uuid
+*please use the following coding instead which is using the function
+*call that was used before but which has been flagged as obsolete
+*in newer SAP releases
+*--------------------------------------------------------------------*
+
+*  CALL FUNCTION 'GUID_CREATE'
+*    IMPORTING
+*      ev_guid_32 = rv_guid.
+
+endmethod.
 
 
 METHOD json_2_abap.

--- a/src/zcl_eui_conv.clas.xml
+++ b/src/zcl_eui_conv.clas.xml
@@ -44,6 +44,12 @@
     </SEOCOMPOTX>
     <SEOCOMPOTX>
      <CLSNAME>ZCL_EUI_CONV</CLSNAME>
+     <CMPNAME>GUID_CREATE</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Wrapper for obsolete function GUID_CREATE</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_EUI_CONV</CLSNAME>
      <CMPNAME>JSON_2_ABAP</CMPNAME>
      <LANGU>E</LANGU>
      <DESCRIPT>https://github.com/cesar-sap/abap_fm_json.git</DESCRIPT>

--- a/src/zcl_eui_event_caller.clas.abap
+++ b/src/zcl_eui_event_caller.clas.abap
@@ -4,6 +4,7 @@ class ZCL_EUI_EVENT_CALLER definition
   create public .
 
 public section.
+  type-pools ABAP .
 
   methods ADD_HANDLER
     importing

--- a/src/zcl_eui_file.clas.abap
+++ b/src/zcl_eui_file.clas.abap
@@ -4,6 +4,7 @@ class ZCL_EUI_FILE definition
   create public .
 
 public section.
+  type-pools OLE2 .
 
   types:
     BEGIN OF TS_EXCEL_MAP,
@@ -156,7 +157,7 @@ METHOD download.
   DATA lt_bin_data   TYPE solix_tab.
   DATA lv_filesize   TYPE i.
   DATA lv_no_ext     TYPE string.
-  DATA lv_guid       TYPE char32.
+  DATA lv_guid       TYPE guid_32.
 
   " Side results of method
   set_full_path( ).
@@ -250,13 +251,7 @@ METHOD download.
             OTHERS = 0 "prevent GUI messages when file not found
         ).
         IF lv_exist  = abap_true.
-          TRY.
-              lv_guid = cl_system_uuid=>create_uuid_x16_static( ).
-            CATCH cx_uuid_error.
-              CONCATENATE sy-datum(4) `-` sy-datum+4(2) `-` sy-datum+6(2) ` `
-                          sy-uzeit(2) `-` sy-uzeit+2(2) `-` sy-uzeit+4(2) INTO lv_guid.
-          ENDTRY.
-
+          lv_guid = ZCL_EUI_CONV=>GUID_CREATE( ).
           CONCATENATE lv_path lv_no_ext ` ` lv_guid `.` iv_default_extension INTO iv_full_path.
         ENDIF.
 

--- a/src/zcl_eui_file_io.clas.abap
+++ b/src/zcl_eui_file_io.clas.abap
@@ -297,6 +297,8 @@ ENDMETHOD.
 
 
 METHOD export_to_itab_xlsx.
+  "NOTE: No cl_fdt_xl_spreadsheet in ABAP 7.01
+
 **********************************************************************
   " Create mapping
 **********************************************************************
@@ -452,6 +454,8 @@ ENDMETHOD.
 
 
 METHOD import_from_itab_xlsx_0.
+  "NOTE: No cl_fdt_xl_spreadsheet in ABAP 7.01
+
   DATA lt_fieldcat    TYPE lvc_t_fcat.
   DATA ls_fieldcat    TYPE REF TO lvc_s_fcat.
   DATA lt_column      TYPE if_fdt_doc_spreadsheet=>t_column.
@@ -554,6 +558,7 @@ ENDMETHOD.
 
 
 METHOD import_from_itab_xlsx_1.
+  "NOTE: No CL_SALV_BS_LEX in ABAP 7.01
   DATA lt_fieldcat TYPE lvc_t_fcat.
   DATA lo_salv_ex_res TYPE REF TO cl_salv_ex_result_data_table.
 

--- a/src/zcl_eui_file_io.clas.locals_imp.abap
+++ b/src/zcl_eui_file_io.clas.locals_imp.abap
@@ -64,8 +64,10 @@ CLASS lcl_helper IMPLEMENTATION.
         WHEN cl_abap_typedescr=>typekind_packed OR cl_abap_typedescr=>typekind_float         OR
           cl_abap_typedescr=>typekind_num OR cl_abap_typedescr=>typekind_int                 OR
           cl_abap_typedescr=>typekind_int1 OR cl_abap_typedescr=>typekind_int2               OR
-          cl_abap_typedescr=>typekind_numeric OR cl_abap_typedescr=>typekind_decfloat        OR
-          cl_abap_typedescr=>typekind_decfloat16 OR cl_abap_typedescr=>typekind_decfloat34.
+          cl_abap_typedescr=>typekind_numeric OR '/' OR 'a' or 'E'. " sync with ZCL_XTT_REPLACE_BLOCK->TREE_INITIALIZE()
+          "cl_abap_typedescr=>typekind_decfloat        OR
+          "cl_abap_typedescr=>typekind_decfloat16 OR
+          "cl_abap_typedescr=>typekind_decfloat34.
           <ls_excel_map>-gen_type = mc_gen_type-number.
 
         WHEN cl_abap_typedescr=>typekind_date.

--- a/src/zcl_eui_manager.clas.abap
+++ b/src/zcl_eui_manager.clas.abap
@@ -3,6 +3,7 @@ class ZCL_EUI_MANAGER definition
   create public .
 
 public section.
+  type-pools ABAP .
 
   interfaces ZIF_EUI_MANAGER .
 
@@ -23,7 +24,7 @@ public section.
   aliases SHOW
     for ZIF_EUI_MANAGER~SHOW .
 
-  constants MC_EUI_SCREEN_FUGR type SYCPROG value 'SAPLZFG_EUI_SCREEN' ##NO_TEXT.
+  constants MC_EUI_SCREEN_FUGR type SYCPROG value 'SAPLZFG_EUI_SCREEN' ##NO_TEXT. "#EC NO_TEXT
 
   methods CONSTRUCTOR
     importing

--- a/src/zcl_eui_menu.clas.abap
+++ b/src/zcl_eui_menu.clas.abap
@@ -4,6 +4,7 @@ class ZCL_EUI_MENU definition
   create public .
 
 public section.
+  type-pools ABAP .
 
   types:
     BEGIN OF ts_menu.

--- a/src/zcl_eui_screen.clas.abap
+++ b/src/zcl_eui_screen.clas.abap
@@ -5,7 +5,9 @@ class ZCL_EUI_SCREEN definition
   create public .
 
 public section.
-
+  type-pools SSCR .
+  type-pools SYDB0 .
+  class ZCL_EUI_TYPE DEFINITION LOAD. "Required in ABAP 7.01
   types:
     TT_SCREEN type STANDARD TABLE OF SCREEN WITH DEFAULT KEY .
   types:

--- a/src/zcl_eui_type.clas.abap
+++ b/src/zcl_eui_type.clas.abap
@@ -4,6 +4,7 @@ class ZCL_EUI_TYPE definition
   create public .
 
 public section.
+  type-pools ABAP .
 
   types:
     BEGIN OF ts_field_desc,


### PR DESCRIPTION
In ABAP 7.01 there is no ##NO_TEXT pragma, so switched to old "#EC NO_TEXT version
Also added required explicit TYPE-POOLS statements in classes